### PR TITLE
Rename ibeis_finfindr to wbia_finfindr

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ python
 Python 2.7.14 (default, Sep 27 2017, 12:15:00)
 [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
->>> import ibeis
->>> ibs = ibeis.opendb()
+>>> import wbia
+>>> ibs = wbia.opendb()
 
 [ibs.__init__] new IBEISController
 [ibs._init_dirs] ibs.dbdir = u'/Datasets/testdb1'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An example of how to design and use a Python module as a plugin in the IBEIS IA 
 Install this plugin as a Python module using
 
 ```bash
-cd ~/code/ibeis_finfindr/
+cd ~/code/wbia_finfindr/
 python setup.py develop
 ```
 
@@ -14,7 +14,7 @@ python setup.py develop
 
 With the plugin installed, register the module name with the `IBEISControl.py` file
 in the ibeis repository located at `ibeis/ibeis/control/IBEISControl.py`.  Register
-the module by adding the string (for example, `ibeis_finfindr`) to the
+the module by adding the string (for example, `wbia_finfindr`) to the
 list `AUTOLOAD_PLUGIN_MODNAMES`.
 
 Then, load the web-based IBEIS IA service and open the URL that is registered with
@@ -27,10 +27,10 @@ python dev.py --web
 
 Navigate in a browser to http://127.0.0.1:5000/api/plugin/example/helloworld/ where
 this returns a formatted JSON response, including the serialized returned value
-from the `ibeis_finfindr_hello_world()` function
+from the `wbia_finfindr_hello_world()` function
 
 ```
-{"status": {"cache": -1, "message": "", "code": 200, "success": true}, "response": "[ibeis_finfindr] hello world with IBEIS controller <IBEISController(testdb1) at 0x11e776e90>"}
+{"status": {"cache": -1, "message": "", "code": 200, "success": true}, "response": "[wbia_finfindr] hello world with IBEIS controller <IBEISController(testdb1) at 0x11e776e90>"}
 ```
 
 # Python API
@@ -50,10 +50,10 @@ Type "help", "copyright", "credits" or "license" for more information.
 [depc] Initialize IMAGES depcache in u'/Datasets/testdb1/_ibsdb/_ibeis_cache'
 [ibs.__init__] END new IBEISController
 
->>> ibs.ibeis_finfindr_hello_world()
-'[ibeis_finfindr] hello world with IBEIS controller <IBEISController(testdb1) at 0x10b24c9d0>'
+>>> ibs.wbia_finfindr_hello_world()
+'[wbia_finfindr] hello world with IBEIS controller <IBEISController(testdb1) at 0x10b24c9d0>'
 ```
 
 The function from the plugin is automatically added as a method to the ibs object
-as `ibs.ibeis_finfindr_hello_world()`, which is registered using the
+as `ibs.wbia_finfindr_hello_world()`, which is registered using the
 `@register_ibs_method decorator`.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ MINOR = 1
 MICRO = 0
 SUFFIX = 'dev0'
 VERSION = '%d.%d.%d.%s' % (MAJOR, MINOR, MICRO, SUFFIX)
-PACKAGES = ['ibeis_finfindr']
+PACKAGES = ['wbia_finfindr']
 
 
 def git_version():
@@ -75,7 +75,7 @@ def git_version():
     return git_revision
 
 
-def write_version_py(filename=os.path.join('ibeis_finfindr', 'version.py')):
+def write_version_py(filename=os.path.join('wbia_finfindr', 'version.py')):
     cnt = """
 # THIS FILE IS GENERATED FROM SETUP.PY
 version = '%(version)s'

--- a/wbia_finfindr/_plugin.py
+++ b/wbia_finfindr/_plugin.py
@@ -250,13 +250,13 @@ def finfindr_feature_extract(ibs, annot_uuid, use_depc=True, config={}, **kwargs
     Gets the finfindr feature representation of an annot
 
     CommandLine:
-        python -m ibeis_finfindr._plugin --test-finfindr_feature_extract
-        python -m ibeis_finfindr._plugin --test-finfindr_feature_extract:0
+        python -m wbia_finfindr._plugin --test-finfindr_feature_extract
+        python -m wbia_finfindr._plugin --test-finfindr_feature_extract:0
 
     Example0:
         >>> # ENABLE_DOCTEST
         >>> import utool as ut
-        >>> import ibeis_finfindr
+        >>> import wbia_finfindr
         >>> import ibeis
         >>> from ibeis.init import sysres
         >>> # The curvrank testdb also uses dolphin dorsals
@@ -290,14 +290,14 @@ def ibeis_plugin_finfindr_identify(
     Matches qaid_list against daid_list using Finfindr
 
     CommandLine:
-        python -m ibeis_finfindr._plugin --test-ibeis_plugin_finfindr_identify
-        python -m ibeis_finfindr._plugin --test-ibeis_plugin_finfindr_identify:0
+        python -m wbia_finfindr._plugin --test-ibeis_plugin_finfindr_identify
+        python -m wbia_finfindr._plugin --test-ibeis_plugin_finfindr_identify:0
 
     Example0:
         >>> # ENABLE_DOCTEST
         >>> import utool as ut
-        >>> import ibeis_finfindr
-        >>> from ibeis_finfindr._plugin import FinfindrRequest
+        >>> import wbia_finfindr
+        >>> from wbia_finfindr._plugin import FinfindrRequest
         >>> import ibeis
         >>> from ibeis.init import sysres
         >>> # The curvrank testdb also uses dolphin dorsals
@@ -372,14 +372,14 @@ def finfindr_aid_feature_dict(ibs, aid_list, skip_failures=False):
     takes as input for its distance func
 
     CommandLine:
-        python -m ibeis_finfindr._plugin --test-finfindr_aid_feature_dict
-        python -m ibeis_finfindr._plugin --test-finfindr_aid_feature_dict:0
+        python -m wbia_finfindr._plugin --test-finfindr_aid_feature_dict
+        python -m wbia_finfindr._plugin --test-finfindr_aid_feature_dict:0
 
     Example0:
         >>> # ENABLE_DOCTEST
         >>> import utool as ut
-        >>> import ibeis_finfindr
-        >>> from ibeis_finfindr._plugin import FinfindrRequest
+        >>> import wbia_finfindr
+        >>> from wbia_finfindr._plugin import FinfindrRequest
         >>> import ibeis
         >>> from ibeis.init import sysres
         >>> # The curvrank testdb also uses dolphin dorsals
@@ -475,13 +475,13 @@ def finfindr_ibeis_distance_list_from_finfindr_result(
         response: the response from finFindR; output of ibeis_plugin_finfindr_identify
 
     CommandLine:
-        python -m ibeis_finfindr._plugin --test-finfindr_ibeis_distance_list_from_finfindr_result
-        python -m ibeis_finfindr._plugin --test-finfindr_ibeis_distance_list_from_finfindr_result:0
+        python -m wbia_finfindr._plugin --test-finfindr_ibeis_distance_list_from_finfindr_result
+        python -m wbia_finfindr._plugin --test-finfindr_ibeis_distance_list_from_finfindr_result:0
 
     Example0:
         >>> # ENABLE_DOCTEST
         >>> import utool as ut
-        >>> import ibeis_finfindr
+        >>> import wbia_finfindr
         >>> import ibeis
         >>> from ibeis.init import sysres
         >>> # The curvrank testdb also uses dolphin dorsals
@@ -740,7 +740,7 @@ class FinfindrConfig(dt.Config):  # NOQA
 
     Example:
         >>> # ENABLE_DOCTEST
-        >>> from ibeis_finfindr._plugin import *  # NOQA
+        >>> from wbia_finfindr._plugin import *  # NOQA
         >>> config = FinfindrConfig()
         >>> result = config.get_cfgstr()
         >>> print(result)
@@ -812,14 +812,14 @@ def ibeis_plugin_finfindr(depc, qaid_list, daid_list, config):
     Matches qaid_list against daid_list using Finfindr
 
     CommandLine:
-        python -m ibeis_finfindr._plugin --exec-ibeis_plugin_finfindr
-        python -m ibeis_finfindr._plugin --exec-ibeis_plugin_finfindr:0
+        python -m wbia_finfindr._plugin --exec-ibeis_plugin_finfindr
+        python -m wbia_finfindr._plugin --exec-ibeis_plugin_finfindr:0
 
     Example0:
         >>> # ENABLE_DOCTEST
         >>> import utool as ut
-        >>> import ibeis_finfindr
-        >>> from ibeis_finfindr._plugin import FinfindrRequest
+        >>> import wbia_finfindr
+        >>> from wbia_finfindr._plugin import FinfindrRequest
         >>> import ibeis
         >>> from ibeis.init import sysres
         >>> # The curvrank testdb also uses dolphin dorsals
@@ -908,7 +908,7 @@ def finfindr_double_check_random_order(ibs, qaid_list, daid_list):
 if __name__ == '__main__':
     r"""
     CommandLine:
-        python -m ibeis_finfindr._plugin --allexamples
+        python -m wbia_finfindr._plugin --allexamples
     """
     import multiprocessing
 


### PR DESCRIPTION
- Rename ibeis_finfindr to wbia_finfindr

  We are renaming all our repos from ibeis to wbia.

- Rename ibeis references to wbia

  We are renaming all our repos from ibeis to wbia.
  
  ```
  git grep -l 'ibeis' | xargs sed -i \
      's/ibeis_plugin/wbia_plugin/g; s/\<ibeis\>\./wbia./g; s/\(import\|from\) ibeis\(.\| \|$\)/\1 wbia\2/g;'
  ```
